### PR TITLE
Fix a few compilation problems

### DIFF
--- a/databases/mariadb-connector-odbc/Makefile
+++ b/databases/mariadb-connector-odbc/Makefile
@@ -27,13 +27,13 @@ CONFLICTS_INSTALL=	mariadb[0-9]*-client-* \
 
 USES=		cmake
 USE_LDCONFIG=	${PREFIX}/lib/mariadbconnector-odbc
-SITESDIR=	${PORTNAME}/${PKGNAMESUFFIX}-${PORTVERSION}/source
+SITESDIR=	${PORTNAME}/connector-odbc-${PORTVERSION}/source
 DOCSDIR=	${PREFIX}/share/doc/mysql
 
 BUILD_DEPENDS=  unixODBC>=2.2.14_1:databases/unixODBC \
-		mariadb-connector-c>=2.3.0:databases/mariadb-connector-c
+		mariadbconnector-c>=2.3.0:databases/mariadb-connector-c
 LIB_DEPENDS=    libodbc.so:databases/unixODBC
-RUN_DEPENDS=	mariadb-connector-c>=2.3.0:databases/mariadb-connector-c
+RUN_DEPENDS=	mariadbconnector-c>=2.3.0:databases/mariadb-connector-c
 
 CMAKE_ARGS+=	-DCOMPILATION_COMMENT="FreeBSD Ports"
 


### PR DESCRIPTION
First: it was trying to download from "http://[url]/mariadb/-connector-odbc-2.0.14/source/mariadb-connector-odbc-2.0.14-ga-src.tar.gz" instead of "http://[url]/mariadb/connector-odbc-2.0.14/source/mariadb-connector-odbc-2.0.14-ga-src.tar.gz" (dash before "connector…")

Second: I don't know where the error comes from, but it needed "mariadbconnector-c" instead of "mariadb-connector-c" for its dependencies. In logs:
"===>   mariadb-connector-odbc-2.0.14 depends on package: mariadb-connector-c>=2.3.0 - not found
===>   Installing existing package /packages/All/mariadbconnector-c-2.3.1_1.txz"